### PR TITLE
Fix compiler warning under gcc

### DIFF
--- a/include/fast_double_parser.h
+++ b/include/fast_double_parser.h
@@ -31,7 +31,7 @@ namespace fast_double_parser {
 #define unlikely(x) __builtin_expect(!!(x), 0)
 #endif // unlikely
 #ifndef really_inline
-#define really_inline __attribute__((always_inline))
+#define really_inline __attribute__((always_inline)) inline
 #endif // really_inline
 #endif // _MSC_VER
 


### PR DESCRIPTION
gcc complains about always_inline if 'inline' isn't also included:

    include/fast_double_parser.h:1305:20: warning: always_inline function might not be inlinable [-Wattributes]

With fix compiles with no warnings on:

    gcc 9.1.1 -std=c++11
    gcc 9.1.1 -std=c++14
    gcc 9.1.1 -std=c++17
    gcc 5.3.1 -std=c++11
    gcc 5.3.1 -std=c++14
    gcc 4.7.0 -std=c++0x
    apple clang 11.0.3 -std=c++11
    apple clang 11.0.3 -std=c++14
    apple clang 11.0.3 -std=c++17