### PR TITLE
Add crack_atof

### DIFF
--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -1,6 +1,7 @@
 
 #include "absl/strings/charconv.h"
 #include "absl/strings/numbers.h"
+#include "dependencies/crack_atof.h"
 #include "fast_double_parser.h"
 
 #include <algorithm>
@@ -29,6 +30,15 @@ double findmax_fast_double_parser(std::vector<std::string> s) {
     bool isok = fast_double_parser::parse_number(st.c_str(), &x);
     if (!isok)
       throw std::runtime_error("bug in findmax_fast_double_parser");
+    answer = answer > x ? answer : x;
+  }
+  return answer;
+}
+
+double findmax_crack_atof(std::vector<std::string> s) {
+  double answer = 0;
+  for (std::string st : s) {
+    double x = crack_atof(st.c_str(), st.c_str() + st.size());
     answer = answer > x ? answer : x;
   }
   return answer;
@@ -196,13 +206,21 @@ void process(std::vector<std::string> lines, size_t volume) {
     if (i > 0)
       printf("fast_double_parser  %.2f MB/s\n", volumeMB * 1000000000 / dif);
     t1 = std::chrono::high_resolution_clock::now();
+    ts = findmax_crack_atof(lines);
+    t2 = std::chrono::high_resolution_clock::now();
+    if (ts == 0)
+      printf("bug\n");
+    dif = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
+    if (i > 0)
+      printf("crack_atof          %.2f MB/s\n", volumeMB * 1000000000 / dif);
+    t1 = std::chrono::high_resolution_clock::now();
     ts = findmax_strtod(lines);
     t2 = std::chrono::high_resolution_clock::now();
     if (ts == 0)
       printf("bug\n");
     dif = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
     if (i > 0)
-      printf("strtod         %.2f MB/s\n", volumeMB * 1000000000 / dif);
+      printf("strtod              %.2f MB/s\n", volumeMB * 1000000000 / dif);
     t1 = std::chrono::high_resolution_clock::now();
     ts = findmax_absl_from_chars(lines);
     t2 = std::chrono::high_resolution_clock::now();
@@ -210,7 +228,7 @@ void process(std::vector<std::string> lines, size_t volume) {
       printf("bug\n");
     dif = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
     if (i > 0)
-      printf("abslfromch     %.2f MB/s\n", volumeMB * 1000000000 / dif);
+      printf("abslfromch          %.2f MB/s\n", volumeMB * 1000000000 / dif);
     t1 = std::chrono::high_resolution_clock::now();
     ts = findmax_absl(lines);
     t2 = std::chrono::high_resolution_clock::now();
@@ -218,7 +236,7 @@ void process(std::vector<std::string> lines, size_t volume) {
       printf("bug\n");
     dif = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
     if (i > 0)
-      printf("absl           %.2f MB/s\n", volumeMB * 1000000000 / dif);
+      printf("absl                %.2f MB/s\n", volumeMB * 1000000000 / dif);
     t1 = std::chrono::high_resolution_clock::now();
     ts = findmax_doubleconversion(lines);
     t2 = std::chrono::high_resolution_clock::now();
@@ -226,7 +244,7 @@ void process(std::vector<std::string> lines, size_t volume) {
       printf("bug\n");
     dif = std::chrono::duration_cast<std::chrono::nanoseconds>(t2 - t1).count();
     if (i > 0)
-      printf("double-conv    %.2f MB/s\n", volumeMB * 1000000000 / dif);
+      printf("double-conv         %.2f MB/s\n", volumeMB * 1000000000 / dif);
     printf("\n\n");
   }
 }

--- a/benchmarks/dependencies/crack_atof.h
+++ b/benchmarks/dependencies/crack_atof.h
@@ -1,0 +1,115 @@
+// https://gist.github.com/oschonrock/a410d4bec6ec1ccc5a3009f0907b3d15
+
+// the C++ STL is a mess for parsing numbers from strings, FAST. from_chars
+// looked good but is not implemented in clang/gcc crack_atof is a very very
+// fast alternative
+
+// Original crack_atof version is at
+// http://crackprogramming.blogspot.sg/2012/10/implement-atof.html But it cannot
+// convert floating point with high +/- exponent. The version below by Tian Bo
+// fixes that problem and improves performance by 10%
+// http://coliru.stacked-crooked.com/a/2e28f0d71f47ca5e
+// Oliver Schonrock: I picked this code up from
+// https://www.codeproject.com/Articles/1130262/Cplusplus-string-view-Conversion-to-Integral-Types
+// See there for benchmarking. It's blistering fast.
+// I am sure it's not 10000% "correct", but when summing 1'000'000 parsed
+// doubles for me in a test, it obtained the exact same result as the vastly
+// slower std::stod. Good enough for me. I recfactored it slightly, changing the
+// signature, see below.
+double pow10(int n) {
+  double ret = 1.0;
+  double r = 10.0;
+  if (n < 0) {
+    n = -n;
+    r = 0.1;
+  }
+
+  while (n) {
+    if (n & 1) {
+      ret *= r;
+    }
+    r *= r;
+    n >>= 1;
+  }
+  return ret;
+}
+
+// this is the same signature as from_chars (which doesn't work for float on
+// gcc/clang) ie it is a [start, end)  (not including *end). Well suited to
+// parsing read only memorymappedfile
+double crack_atof(const char *num, const char *const end) {
+  if (!num || !end || end <= num) {
+    return 0;
+  }
+
+  int sign = 1;
+  double int_part = 0.0;
+  double frac_part = 0.0;
+  bool has_frac = false;
+  bool has_exp = false;
+
+  // +/- sign
+  if (*num == '-') {
+    ++num;
+    sign = -1;
+  } else if (*num == '+') {
+    ++num;
+  }
+
+  while (num != end) {
+    if (*num >= '0' && *num <= '9') {
+      int_part = int_part * 10 + (*num - '0');
+    } else if (*num == '.') {
+      has_frac = true;
+      ++num;
+      break;
+    } else if (*num == 'e') {
+      has_exp = true;
+      ++num;
+      break;
+    } else {
+      return sign * int_part;
+    }
+    ++num;
+  }
+
+  if (has_frac) {
+    double frac_exp = 0.1;
+
+    while (num != end) {
+      if (*num >= '0' && *num <= '9') {
+        frac_part += frac_exp * (*num - '0');
+        frac_exp *= 0.1;
+      } else if (*num == 'e') {
+        has_exp = true;
+        ++num;
+        break;
+      } else {
+        return sign * (int_part + frac_part);
+      }
+      ++num;
+    }
+  }
+
+  // parsing exponent part
+  double exp_part = 1.0;
+  if (num != end && has_exp) {
+    int exp_sign = 1;
+    if (*num == '-') {
+      exp_sign = -1;
+      ++num;
+    } else if (*num == '+') {
+      ++num;
+    }
+
+    int e = 0;
+    while (num != end && *num >= '0' && *num <= '9') {
+      e = e * 10 + *num - '0';
+      ++num;
+    }
+
+    exp_part = pow10(exp_sign * e);
+  }
+
+  return sign * (int_part + frac_part) * exp_part;
+}


### PR DESCRIPTION
This snippet floating around web is very fast despite its simplicity.
Its correctness is not thoroughly tested though.

```
❯ make bench
./benchmark 
parsing random integers in the range [0,1)


=== trial 1 ===
fast_double_parser  500.07 MB/s
crack_atof          463.06 MB/s
strtod              89.98 MB/s
abslfromch          162.10 MB/s
absl                143.57 MB/s
double-conv         168.40 MB/s


=== trial 2 ===
fast_double_parser  497.38 MB/s
crack_atof          462.21 MB/s
strtod              89.98 MB/s
abslfromch          161.66 MB/s
absl                143.42 MB/s
double-conv         168.44 MB/s


You can also provide a filename: it should contain one string per line corresponding to a number
./benchmark benchmarks/data/canada.txt
read 111126 lines 


=== trial 1 ===
fast_double_parser  286.54 MB/s
crack_atof          260.82 MB/s
strtod              106.76 MB/s
abslfromch          194.86 MB/s
absl                183.40 MB/s
double-conv         127.71 MB/s


=== trial 2 ===
fast_double_parser  289.19 MB/s
crack_atof          260.41 MB/s
strtod              105.83 MB/s
abslfromch          195.41 MB/s
absl                184.24 MB/s
double-conv         126.81 MB/s
```