### PR TITLE
Missing inline.

### DIFF
--- a/include/fast_double_parser.h
+++ b/include/fast_double_parser.h
@@ -93,7 +93,7 @@ really_inline value128 full_multiplication(uint64_t value1, uint64_t value2) {
 
 
 /* result might be undefined when input_num is zero */
-int leading_zeroes(uint64_t input_num) {
+inline int leading_zeroes(uint64_t input_num) {
 #ifdef _MSC_VER
   unsigned long leading_zero = 0;
   // Search the mask data from most significant bit (MSB)


### PR DESCRIPTION
Thanks for publishing this library!

This `inline` seems to be necessary to include `fast_double_parser.h` in more than one compilation unit.
