### PR TITLE
handle `0.` correctly as a float

### DIFF
--- a/include/fast_double_parser.h
+++ b/include/fast_double_parser.h
@@ -1184,6 +1184,10 @@ really_inline const char * parse_number(const char *p, double *outDouble) {
                           // cheaper than arbitrary mult.
       // we will handle the overflow later
     } else {
+      if (*p == '\0') {
+        *outDouble = 0;
+        return p;
+      }
       return nullptr;
     }
     while (is_integer(*p)) {


### PR DESCRIPTION
### Before

`0.` will return nullptr

### After 

`0.` will return (float) 0

### Surrounding logic

If the first char after the dot `.` does not pass `if (is_integer(*p))`, then `return nullptr`. The problem is when there is nothing after the dot, meaning `*p == '\0'`, it is also a valid number and people might use it in some places. 
