### PR TITLE
Update jwlawson/actions-setup-cmake in GitHub Actions to v1.13

### DIFF
--- a/.github/workflows/ubuntu18.yml
+++ b/.github/workflows/ubuntu18.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.4
+        uses: jwlawson/actions-setup-cmake@v1.13
         with:
           cmake-version: '3.9.x'
       - name: Use cmake

--- a/.github/workflows/ubuntu20.yml
+++ b/.github/workflows/ubuntu20.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@v1.4
+        uses: jwlawson/actions-setup-cmake@v1.13
         with:
           cmake-version: '3.9.x'
       - name: Use cmake


### PR DESCRIPTION
Updates the `jwlawson/actions-setup-cmake` action used in the GitHub Actions workflows to its newest minor version.

For changes in [jwlawson/actions-setup-cmake](https://github.com/jwlawson/actions-setup-cmake) see https://github.com/jwlawson/actions-setup-cmake/releases.

Still using v1.4 of `jwlawson/actions-setup-cmake` will generate some warning like in this run: https://github.com/lemire/fast_double_parser/actions/runs/3830465181

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: jwlawson/actions-setup-cmake@v1.4

The PR will get rid of those warning, because v1.13 uses Node.js 16.