### PR TITLE
Add ClusterFuzzLite integration

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/fast_double_parser
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/fast_double_parser

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,3 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+# Copy all fuzzer executable to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/fast_double_parser/.clusterfuzzlite/parse_number_fuzzer.cpp \
+  -o $OUT/parse_number_fuzzer \
+  -I$SRC/fast_double_parser/include

--- a/.clusterfuzzlite/parse_number_fuzzer.cpp
+++ b/.clusterfuzzlite/parse_number_fuzzer.cpp
@@ -1,0 +1,11 @@
+#include <fast_double_parser.h>
+#include <string>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  std::string fuzz_input(reinterpret_cast<const char *>(data), size);
+
+  double x;
+  fast_double_parser::parse_number(fuzz_input.c_str(), &x);
+
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
It would be great to fuzz the parsing logic, but I think it might be a bit too small for continuous fuzzing by way of OSS-Fuzz. This PR adds ClusterFuzzLite such that fuzzers are run on each PR for 100 seconds, and if a PR introduces breaking changes it will be flagged. The duration can be adjusted.