### PR TITLE
Add a simple Bazel module and build file.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,12 @@
+cc_library(
+    name = "fast_double_parser",
+    hdrs = ["include/fast_double_parser.h"],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+)
+
+cc_test(
+    name = "unit",
+    srcs = ["tests/unit.cpp"],
+    deps = [":fast_double_parser"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,7 @@
+"""fast_double_parser: 4x faster than strtod."""
+
+module(
+    name = "fast_double_parser",
+    version = "0.8.0",
+    compatibility_level = 0,
+)

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ double-conv    243.90 MB/s
 - [There is a Rust port](https://github.com/ezrosent/frawk/tree/master/src/runtime/float_parse).
 - [There is a Java port](https://github.com/wrandelshofer/FastDoubleParser).
 - [There is a C# port](https://github.com/CarlVerret/csFastFloat).
+- [Bazel Central Registry](https://registry.bazel.build/modules/fast_double_parser).
 
 ## Credit
 


### PR DESCRIPTION
Hi authors of fast_double_parser,

I recently ported this excellent library to the Bazel Central Registry. Originated from Google's internal tools, Bazel is an open-source build tool adopted by many companies in the industry as well as open source projects. With Bazel, users can simply import this library by defining in their project `MODULE.bazel`:

```
bazel_dep(name = "fast_double_parser", version = "0.8.0")
```

Bazel Central Registry: https://registry.bazel.build/modules/fast_double_parser

Although the build rules are added into the repository of the Bazel Central Registry [here](https://github.com/bazelbuild/bazel-central-registry/tree/faa687531fbe0137880c416ce711468da8e5edff/modules/fast_double_parser/0.8.0), it would be still a great idea to upstream the change to the original repository.

As you can see, the build rule is really simple, so it shouldn't add much maintenance cost to this project. With this patch, you can also run `bazel test //:unit` to run the unit test. If you are interested, I can also help add build rules for the benchmark.

Best regards,
Carbo