### PR TITLE
Add benchmark binary to Bazel BUILD.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,3 +10,13 @@ cc_test(
     srcs = ["tests/unit.cpp"],
     deps = [":fast_double_parser"],
 )
+
+cc_binary(
+    name = "benchmark",
+    srcs = ["benchmarks/benchmark.cpp"],
+    deps = [
+        ":fast_double_parser",
+        "@abseil-cpp//absl/strings",
+        "@double-conversion",
+    ],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,3 +5,6 @@ module(
     version = "0.8.0",
     compatibility_level = 0,
 )
+
+bazel_dep(name = "abseil-cpp", version = "20240722.0", dev_dependency = True)
+bazel_dep(name = "double-conversion", version = "3.3.0", dev_dependency = True)


### PR DESCRIPTION
To build it, run:
```bazel build --compilation_mode=opt //:benchmark```

To run the benchmark, run:
```bazel-bin/benchmark benchmarks/data/canada.txt```

Result from my computer:

```
read 111126 lines

=== trial 1 ===
fast_double_parser  1315.70 MB/s
strtod         722.10 MB/s
abslfromch     810.26 MB/s
absl           799.89 MB/s
double-conv    396.05 MB/s

=== trial 2 ===
fast_double_parser  1416.58 MB/s
strtod         751.43 MB/s
abslfromch     841.83 MB/s
absl           838.71 MB/s
double-conv    415.33 MB/s
```